### PR TITLE
Change author order

### DIFF
--- a/_posts/2020-06-03-fatras20a.md
+++ b/_posts/2020-06-03-fatras20a.md
@@ -21,19 +21,19 @@ lastpage: 2141
 page: 2131-2141
 order: 2131
 cycles: false
-bibtex_author: Fatras, Kilian and Courty, Nicolas and Flamary, R\'emi and Zine, Younes
-  and Gribonval, Remi
+bibtex_author: Fatras, Kilian and Zine, Younes and Flamary, R\'emi
+  and Gribonval, Remi and Courty, Nicolas
 author:
 - given: Kilian
   family: Fatras
-- given: Nicolas
-  family: Courty
-- given: Rémi
-  family: Flamary
 - given: Younes
   family: Zine
+- given: Rémi
+  family: Flamary
 - given: Remi
   family: Gribonval
+- given: Nicolas
+  family: Courty
 date: 2020-06-03
 address: 
 publisher: PMLR


### PR DESCRIPTION
Hello,

There was a mistake regarding author order. Younès Zine is the 2nd author and Nicolas Courty the last one, as stated in the paper. We are sorry to not have spotted this mistake before and we hope we can change it now.

Best regards,

Kilian Fatras