### PR TITLE
Correct typo in the name of the paper

### DIFF
--- a/_posts/2020-06-03-pedregosa20a.md
+++ b/_posts/2020-06-03-pedregosa20a.md
@@ -1,5 +1,5 @@
 ---
-title: Linearly Convergent Frank-Wolfe without Line-Search
+title: Linearly Convergent Frank-Wolfe with Backtracking Line-Search
 abstract: 'Structured constraints in Machine Learning have recently brought the Frank-Wolfe
   (FW) family of algorithms back in the spotlight. While the classical FW algorithm
   has poor local convergence properties, the Away-steps and Pairwise FW variants have
@@ -17,7 +17,7 @@ layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: pedregosa20a
 month: 0
-tex_title: Linearly Convergent Frank-Wolfe without Line-Search
+tex_title: Linearly Convergent Frank-Wolfe with Backtracking Line-Search
 firstpage: 1
 lastpage: 10
 page: 1-10


### PR DESCRIPTION
There was a mismatch between the title in the PDF and in the webpage. Thanks!